### PR TITLE
Fixed WORK vs WEBWORK issue

### DIFF
--- a/SGF2020-Paper-Simple_and_Efficient_Bootstrap_Validation-Examples.sas
+++ b/SGF2020-Paper-Simple_and_Efficient_Bootstrap_Validation-Examples.sas
@@ -44,7 +44,7 @@ Pre-example Setup Part 3
 The code below subsets the dataset downloaded above to rows with no missing values for the predicator variables, as well as creating a response variable. Only SAS log output should be created.
 */
 data example_dataset;
-    set analysis_data;
+    set work.analysis_data;
     
     * Create outcome variable;
     if (&response_variable_condition.) then &response_variable. = 1;


### PR DESCRIPTION
When using UE in interactive mode, SAS studio defaults to using the WEBWORK directory rather than WORK. This caused a "dataset does not exist" error. This was fixed by explicitly referencing WORK.ANALYSIS_DATA.